### PR TITLE
Fix warnings & remove nightly feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ A minimal deserializer for inspecting `std::backtrace::Backtrace`'s Debug format
 keywords = ["backtrace", "std", "parse"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+rust-version = "1.65"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 //! An error utility library for deserializing `std::backtrace::Backtrace`'s
 //! based on its `Debug` format.
 #![doc(html_root_url = "https://docs.rs/btparse/0.1.1")]
-#![feature(backtrace)]
 #![allow(clippy::try_err)]
 use std::fmt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,6 @@ pub struct Error {
 #[derive(Debug)]
 enum Kind {
     Disabled,
-    Empty,
     Unsupported,
     UnexpectedInput(String),
     InvalidInput { expected: String, found: String },
@@ -60,7 +59,6 @@ impl fmt::Display for Kind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Disabled => write!(f, "backtrace capture disabled"),
-            Self::Empty => write!(f, "input is empty"),
             Self::Unsupported => write!(f, "backtrace capture unsupported on this platform"),
             Self::UnexpectedInput(input) => write!(f, "encountered unexpected input: {:?}", input),
             Self::InvalidInput { expected, found } => write!(
@@ -68,8 +66,8 @@ impl fmt::Display for Kind {
                 "invalid input, expected: {:?}, found: {:?}",
                 expected, found
             ),
-            Self::LineParse(input, _) => {
-                write!(f, "invalid line input for line number: {:?}", input)
+            Self::LineParse(input, e) => {
+                write!(f, "invalid line input for line number: {:?} ({:?})", input, e)
             }
         }
     }


### PR DESCRIPTION
Hi Jane! It look me like, uhhm, 4 years or so, but I finally got around to adding this into `color-backtrace` today ([branch](https://github.com/athre0z/color-backtrace/tree/btparse))! The `btparse` code hasn't been touched in years, yet it still parses traces fine on latest Rust, so I take that as a hint that it may work just fine for quite a while in the future.

I didn't notice it locally (`rustup default nightly`), but I realized that the lib still relies on the [old feature flag when pushing the changes into CI](https://github.com/athre0z/color-backtrace/actions/runs/9906876733/job/27369365550).

While removing the feature flag I also noticed two warnings about unused enum variants / fields which I fixed by getting rid of it / printing the field respectively.

If you don't want to maintain this anymore, that's also no problem -- please just let me know & I'll paste the code over into color-backtrace.

Resolves #4