### PR TITLE
Bump version to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+## [0.2.0] - 2024-09-01
+- Introduce MSRV and set it to 1.65
+- Remove `backtrace` nightly feature, allowing the crate to compile on stable Rust
+
 ## [0.1.1] - 2020-11-18
 ### Fixed
 - Exposed the `frames` within a parsed backtrace so this crate is actually

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btparse"
-version = "0.1.2-alpha.0"
+version = "0.2.0"
 authors = ["Jane Lusby <jlusby@yaah.dev>"]
 edition = "2018"
 repository = "https://github.com/yaahc/btparse"


### PR DESCRIPTION
Hey Jane! I updated my color-backtrace branch, checked everything against the CI with the btparse dep pinned to 54f9ddb8c7c8f8e034226fdcacab93cd76e1453b from this PR and it seems to be working fine one stable now, as far as I can tell. Please let me know if we need to update anything else before releasing `0.2.0`. I'll publish a new version + create a git tag once you approved and we merged this PR.